### PR TITLE
Reset lastPieceMoved in Board reset()

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -56,6 +56,7 @@ export class Board {
     reset() {
         this.board = Array.from(new Array(8), () => new Array(8));
         this.takenPieces.clear();
+        this.lastPieceMoved = null;
     }
 
     /**


### PR DESCRIPTION
Reset the `lastPieceMoved` attribute in the `Board` class's `reset()` function.